### PR TITLE
Fix tag editor: new tags not saved + UX improvements

### DIFF
--- a/src/components/ReadingItem.tsx
+++ b/src/components/ReadingItem.tsx
@@ -202,7 +202,7 @@ export function ReadingItem({
           >
             <div
               style={{ borderTop: '1px solid var(--border)' }}
-              className="mt-3 pt-3 flex flex-col gap-2.5"
+              className="mt-3 pt-3 px-8 flex flex-col gap-2.5"
             >
               {/* All available tags */}
               {allTags.length > 0 && (
@@ -255,6 +255,13 @@ export function ReadingItem({
                 >
                   <Plus size={11} />
                   Add
+                </button>
+                <button
+                  onClick={() => setEditingTags(false)}
+                  style={{ background: 'var(--border)', color: 'var(--text-muted)' }}
+                  className="text-xs px-2.5 py-1 rounded-md hover:opacity-80 transition-opacity"
+                >
+                  Done
                 </button>
               </div>
             </div>

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -59,6 +59,9 @@ export async function updateItemTags(
   data.items = data.items.map((item) =>
     item.id === id ? { ...item, tags } : item,
   );
+  // Also register any new tags globally in the same write
+  const merged = new Set([...data.tags, ...tags]);
+  data.tags = [...merged].sort();
   await saveStorage(data);
 }
 


### PR DESCRIPTION
## Summary
- **Fix race condition** in `updateItemTags` — new tags added inline were lost because two concurrent storage writes overwrote each other. Now tags are added to the global list atomically in the same write.
- **Add padding** to the tag editor panel so it aligns with item content instead of sticking to the edges.
- **Add Done button** next to the Add button so users can easily close the tag editor without hunting for the small tag icon.

Fixes #1

## Test plan
- [x] Add a new tag from an item's inline tag editor
- [x] Verify it appears in the sidebar tag list immediately
- [x] Verify the tag editor has proper padding on both sides
- [x] Verify the Done button closes the tag editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)