### PR TITLE
Fix date group ordering and add item left padding

### DIFF
--- a/src/components/ReadingItem.tsx
+++ b/src/components/ReadingItem.tsx
@@ -75,7 +75,7 @@ export function ReadingItem({
       className="relative flex flex-col py-3.5 transition-colors duration-150"
     >
       {/* ── Main row ── */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 pl-3">
         {/* Checkbox / archive indicator — hidden until hover */}
         {!isArchived ? (
           <button

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -29,9 +29,9 @@ const GROUP_ORDER: Record<string, number> = {
 
 function groupOrder(label: string): number {
   if (label in GROUP_ORDER) return GROUP_ORDER[label];
-  // For "Month Year" labels, parse them so newest comes first
+  // Month labels come after Today/Yesterday/This Week, newest month first
   const date = new Date(label);
-  if (!isNaN(date.getTime())) return -(date.getTime());
+  if (!isNaN(date.getTime())) return 3 + (1 / date.getTime());
   return 999;
 }
 
@@ -48,8 +48,18 @@ export function groupItemsByDate(
   }
 
   // Sort groups: Today → Yesterday → This Week → oldest months
+  // Sort items within each group: newest first
   const sorted = new Map(
-    [...groups.entries()].sort(([a], [b]) => groupOrder(a) - groupOrder(b)),
+    [...groups.entries()]
+      .sort(([a], [b]) => groupOrder(a) - groupOrder(b))
+      .map(([label, groupItems]) => {
+        groupItems.sort((a, b) => {
+          const tsA = a.archived ? (a.archivedAt ?? a.dateAdded) : a.dateAdded;
+          const tsB = b.archived ? (b.archivedAt ?? b.dateAdded) : b.dateAdded;
+          return tsB - tsA;
+        });
+        return [label, groupItems] as [DateGroupLabel, ReadingItem[]];
+      }),
   );
 
   return sorted;


### PR DESCRIPTION
## Summary
- **Fix group sort order** — Today/Yesterday/This Week now always appear before month labels. Previously, negative timestamps caused month groups to sort above the fixed labels.
- **Sort items newest first** within each date group.
- **Add left padding** (`pl-3`) to item rows so the checkbox isn't flush against the left edge.

## Test plan
- [ ] Add a new item and verify it appears at the top under "Today"
- [ ] Verify "Today" group appears above older month groups
- [ ] Verify items within a group are ordered newest first
- [ ] Verify the checkbox has padding from the left edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)